### PR TITLE
Fixed redundancy in Linea.m class

### DIFF
--- a/Clases/Semana05_IntroPOO/Linea.m
+++ b/Clases/Semana05_IntroPOO/Linea.m
@@ -16,52 +16,35 @@ classdef Linea < handle
         end
         
         function graficar(obj)
+            close all
+            figure;
             plot([obj.pntA.x, obj.pntB.x], ...
                 [obj.pntA.y, obj.pntB.y], "r*-");
+            axis([-10 10 -10 10])
         end
         
         function movUp(obj,u)
-            close all
             obj.pntA.y = obj.pntA.y + u;
             obj.pntB.y = obj.pntB.y + u;
-            figure;
-            plot([obj.pntA.x, obj.pntB.x], ...
-                [obj.pntA.y, obj.pntB.y], "r*-");
-            
-            axis([-10 10 -10 10])
+            obj.graficar();
         end
       
         function movDown(obj,u)
-            close all
             obj.pntA.y = obj.pntA.y - u;
             obj.pntB.y = obj.pntB.y - u;
-            figure;
-            plot([obj.pntA.x, obj.pntB.x], ...
-                [obj.pntA.y, obj.pntB.y], "r*-");
-            
-            axis([-10 10 -10 10])
+            obj.graficar();
         end
         
         function movLft(obj,u)
-            close all
             obj.pntA.x = obj.pntA.x - u;
             obj.pntB.x = obj.pntB.x - u;
-            figure;
-            plot([obj.pntA.x, obj.pntB.x], ...
-                [obj.pntA.y, obj.pntB.y], "r*-");
-            
-            axis([-10 10 -10 10])
+            obj.graficar();
         end
         
         function movRgt(obj,u)
-            close all
             obj.pntA.x = obj.pntA.x + u;
             obj.pntB.x = obj.pntB.x + u;
-            figure;
-            plot([obj.pntA.x, obj.pntB.x], ...
-                [obj.pntA.y, obj.pntB.y], "r*-");
-            
-            axis([-10 10 -10 10])
+            obj.graficar();
         end
         
     end


### PR DESCRIPTION
Fix:
- Linea.graficar() now closes all figures then pop up a figure with axes predefined to plot the line
- The methods for move the line now calls graficar() for avoid code redundancy

